### PR TITLE
feat: bundle MQ redistributable in sync script

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,10 @@ Run inside a `manylinux` container:
 MQ_CLIENT_TAR_URL=<url to MQ client> scripts/build_manylinux.sh
 ```
 
-The script synchronizes the PyMQI sources, builds wheels for CPython 3.8–3.12
-and repairs them with `auditwheel`.
+The script synchronizes the PyMQI sources, downloads the IBM MQ client
+redistributable package and extracts the required headers and libraries using
+`genmqpkg.sh`. It then builds wheels for CPython 3.8–3.12 and repairs them with
+`auditwheel`.
 
 ### Windows
 Use the PowerShell script `scripts/build_windows.ps1` from a Visual Studio

--- a/scripts/build_manylinux.sh
+++ b/scripts/build_manylinux.sh
@@ -8,18 +8,15 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENDOR_DIR="$ROOT_DIR/vendor/mq"
 
 rm -rf "$VENDOR_DIR"
-mkdir -p "$VENDOR_DIR"
 
-if [[ -n "${MQ_CLIENT_TAR_PATH:-}" ]]; then
-  tar -xzf "$MQ_CLIENT_TAR_PATH" -C "$VENDOR_DIR" --strip-components=1
-elif [[ -n "${MQ_CLIENT_TAR_URL:-}" ]]; then
-  curl -L "$MQ_CLIENT_TAR_URL" | tar -xz -C "$VENDOR_DIR" --strip-components=1
-else
+if [[ -z "${MQ_CLIENT_TAR_PATH:-}" && -z "${MQ_CLIENT_TAR_URL:-}" ]]; then
   echo "Provide MQ_CLIENT_TAR_URL or MQ_CLIENT_TAR_PATH" >&2
   exit 1
 fi
 
 "$ROOT_DIR/scripts/sync_upstream.sh"
+
+unset MQ_CLIENT_TAR_URL MQ_CLIENT_TAR_PATH
 
 for PYVER in cp38 cp39 cp310 cp311 cp312; do
   PYBIN="/opt/python/${PYVER}/bin"

--- a/scripts/sync_upstream.sh
+++ b/scripts/sync_upstream.sh
@@ -26,3 +26,32 @@ rsync -a --delete "$SRC_DIR/pymqi/" "$ROOT_DIR/src/pymqi/"
 # Preserve upstream license
 LICENSE_DST="$ROOT_DIR/LICENSE-THIRD-PARTY"
 cp "$SRC_DIR/LICENSE" "$LICENSE_DST"
+
+# ---------------------------------------------------------------------------
+# Optionally download and prepare the IBM MQ runtime
+# ---------------------------------------------------------------------------
+VENDOR_DIR="$ROOT_DIR/vendor/mq"
+MQ_BUILD_DIR="$BUILD_DIR/mq-src"
+
+if [[ -n "${MQ_CLIENT_TAR_PATH:-}" || -n "${MQ_CLIENT_TAR_URL:-}" ]]; then
+  rm -rf "$VENDOR_DIR" "$MQ_BUILD_DIR"
+  mkdir -p "$VENDOR_DIR" "$MQ_BUILD_DIR"
+
+  MQ_CLIENT_TAR_PATH="${MQ_CLIENT_TAR_PATH:-$BUILD_DIR/mq-client.tar.gz}"
+  if [[ -n "${MQ_CLIENT_TAR_URL:-}" && ! -f "$MQ_CLIENT_TAR_PATH" ]]; then
+    curl -L "$MQ_CLIENT_TAR_URL" -o "$MQ_CLIENT_TAR_PATH"
+  fi
+
+  tar -xzf "$MQ_CLIENT_TAR_PATH" -C "$MQ_BUILD_DIR"
+  MQ_SRC_DIR="$(find "$MQ_BUILD_DIR" -mindepth 1 -maxdepth 1 -type d | head -n1)"
+
+  if [[ -x "$MQ_SRC_DIR/mqlicense.sh" ]]; then
+    "$MQ_SRC_DIR/mqlicense.sh" -accept
+  fi
+
+  "$MQ_SRC_DIR/genmqpkg.sh" -b "$VENDOR_DIR"
+
+  if [[ -d "$VENDOR_DIR/inc" ]]; then
+    mv "$VENDOR_DIR/inc" "$VENDOR_DIR/include"
+  fi
+fi


### PR DESCRIPTION
## Summary
- download and extract IBM MQ redistributable with `genmqpkg.sh`
- simplify manylinux build to delegate MQ client setup to sync script
- document MQ download step in README

## Testing
- `ruff src tests`
- `black --check src tests`
- `mypy src`
- `PYTHONPATH=src pytest`
- `python -m pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools>=40.8.0)*

------
https://chatgpt.com/codex/tasks/task_e_68af0b3aeecc8325918c8438d772736e