### PR TITLE
Support Python 3.6 and fix download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ need a system wide installation of the MQ libraries.
 
 ## Features
 
-- Works with Python 3.8 through 3.12.
+- Works with Python 3.6 through 3.12.
 - Linux wheels are built as `manylinux2014_x86_64` (or `manylinux_2_28_x86_64`).
 - Windows wheels bundle the required DLLs using [delvewheel](https://github.com/adang1345/delvewheel).
 - Pure Python API compatible with `pymqi` while keeping the import name `pymqi`.
@@ -14,6 +14,22 @@ need a system wide installation of the MQ libraries.
 The upstream PyMQI sources are synchronized during the build process. See
 [`scripts/sync_upstream.sh`](scripts/sync_upstream.sh) and the preserved license in
 `LICENSE-THIRD-PARTY`.
+
+## Build prerequisites
+
+Install required system tools (example for yum-based distributions):
+
+```bash
+yum install -y gcc make curl tar rsync
+```
+
+Python packages needed for building:
+
+```bash
+python -m pip install build
+# Python 3.6 additionally requires the dataclasses backport
+python -m pip install dataclasses
+```
 
 ## Running
 
@@ -80,13 +96,13 @@ vendor/mq/
 Run inside a `manylinux` container:
 
 ```bash
-MQ_CLIENT_TAR_URL=<url to MQ client> scripts/build_manylinux.sh
+scripts/build_manylinux.sh
 ```
 
 The script synchronizes the PyMQI sources, downloads the IBM MQ client
-redistributable package and extracts the required headers and libraries using
-`genmqpkg.sh`. It then builds wheels for CPython 3.8–3.12 and repairs them with
-`auditwheel`.
+redistributable package (using a default IBM link) and extracts the required
+headers and libraries using `genmqpkg.sh`. It then builds wheels for CPython
+3.6–3.12 and repairs them with `auditwheel`.
 
 ### Windows
 Use the PowerShell script `scripts/build_windows.ps1` from a Visual Studio

--- a/scripts/build_manylinux.sh
+++ b/scripts/build_manylinux.sh
@@ -2,23 +2,20 @@
 set -euo pipefail
 
 # Build manylinux wheels bundling the IBM MQ Client.
-# Provide MQ_CLIENT_TAR_URL or MQ_CLIENT_TAR_PATH to supply the MQ runtime.
+# Downloads the MQ runtime if not supplied via MQ_CLIENT_TAR_URL or MQ_CLIENT_TAR_PATH.
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 VENDOR_DIR="$ROOT_DIR/vendor/mq"
 
 rm -rf "$VENDOR_DIR"
 
-if [[ -z "${MQ_CLIENT_TAR_PATH:-}" && -z "${MQ_CLIENT_TAR_URL:-}" ]]; then
-  echo "Provide MQ_CLIENT_TAR_URL or MQ_CLIENT_TAR_PATH" >&2
-  exit 1
-fi
+MQ_CLIENT_TAR_URL="${MQ_CLIENT_TAR_URL:-https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.5.0-IBM-MQC-Redist-LinuxX64.tar.gz}"
 
 "$ROOT_DIR/scripts/sync_upstream.sh"
 
 unset MQ_CLIENT_TAR_URL MQ_CLIENT_TAR_PATH
 
-for PYVER in cp38 cp39 cp310 cp311 cp312; do
+for PYVER in cp36 cp37 cp38 cp39 cp310 cp311 cp312; do
   PYBIN="/opt/python/${PYVER}/bin"
   MQ_INSTALLATION_PATH="$VENDOR_DIR" "$PYBIN/python" -m build --wheel
   for whl in dist/pymqi_embedded-*.whl; do

--- a/scripts/sync_upstream.sh
+++ b/scripts/sync_upstream.sh
@@ -9,7 +9,6 @@ BUILD_DIR="$ROOT_DIR/.build"
 SRC_DIR="$BUILD_DIR/pymqi-src"
 
 PYMQI_VERSION="${PYMQI_VERSION:-1.13.1}"
-SDIST_URL="https://files.pythonhosted.org/packages/source/p/pymqi/pymqi-${PYMQI_VERSION}.tar.gz"
 SDIST_PATH="${PYMQI_SDIST_PATH:-$BUILD_DIR/pymqi-${PYMQI_VERSION}.tar.gz}"
 
 rm -rf "$SRC_DIR"
@@ -17,7 +16,8 @@ mkdir -p "$SRC_DIR"
 mkdir -p "$ROOT_DIR/src/pymqi"
 
 if [ ! -f "$SDIST_PATH" ]; then
-  curl -L "$SDIST_URL" -o "$SDIST_PATH"
+  python -m pip download --no-binary :all: "pymqi==${PYMQI_VERSION}" -d "$BUILD_DIR"
+  SDIST_PATH="$BUILD_DIR/pymqi-${PYMQI_VERSION}.tar.gz"
 fi
 
 tar -xzf "$SDIST_PATH" -C "$SRC_DIR" --strip-components=1
@@ -32,6 +32,7 @@ cp "$SRC_DIR/LICENSE" "$LICENSE_DST"
 # ---------------------------------------------------------------------------
 VENDOR_DIR="$ROOT_DIR/vendor/mq"
 MQ_BUILD_DIR="$BUILD_DIR/mq-src"
+MQ_CLIENT_TAR_URL="${MQ_CLIENT_TAR_URL:-https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/messaging/mqdev/redist/9.3.5.0-IBM-MQC-Redist-LinuxX64.tar.gz}"
 
 if [[ -n "${MQ_CLIENT_TAR_PATH:-}" || -n "${MQ_CLIENT_TAR_URL:-}" ]]; then
   rm -rf "$VENDOR_DIR" "$MQ_BUILD_DIR"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import shutil
 from pathlib import Path
@@ -84,6 +82,8 @@ setup(
         "Operating System :: Microsoft :: Windows",
         "Operating System :: POSIX :: Linux",
     ],
+    python_requires=">=3.6",
+    install_requires=["dataclasses; python_version < '3.7'"],
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,

--- a/src/pymqi/__init__.py
+++ b/src/pymqi/__init__.py
@@ -1,9 +1,7 @@
 """Simplified PyMQI API for testing purposes."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
-from typing import Any, List, Tuple
+from typing import Any, List, Optional, Tuple
 
 from ._version import __version__
 
@@ -37,12 +35,12 @@ class Queue:
 __all__ = ["QueueManager", "Queue", "__version__"]
 
 
-def MQCONNX(qmgr_name: str, cd: Any | None) -> Tuple[int, int]:
+def MQCONNX(qmgr_name: str, cd: Optional[Any]) -> Tuple[int, int]:
     """Stub MQCONNX returning success."""
     return 0, 0  # pragma: no cover - placeholder
 
 
-def MQDISC(hconn: Any | None) -> Tuple[int, int]:
+def MQDISC(hconn: Optional[Any]) -> Tuple[int, int]:
     """Stub MQDISC returning success."""
     return 0, 0  # pragma: no cover - placeholder
 


### PR DESCRIPTION
## Summary
- expand Python compatibility to 3.6 and require the dataclasses backport when needed
- fix PyMQI and IBM MQ Client download logic and add defaults for the redistributable
- document build prerequisites for yum and pip

## Testing
- `ruff src tests`
- `black --check src tests`
- `mypy src`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68af44a77de483259e9904c651f94879