### PR TITLE
build: bootstrap setuptools in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,28 @@ The upstream PyMQI sources are synchronized during the build process. See
 [`scripts/sync_upstream.py`](scripts/sync_upstream.py) and the preserved license in
 `LICENSE-THIRD-PARTY`.
 
-## Build prerequisites
+## Quick build
 
-Install required system tools (example for yum-based distributions):
+To verify the source tree and produce distributable artifacts run:
 
 ```bash
-yum install -y gcc make curl tar rsync
+python -m compileall
+python setup.py sdist bdist_wheel
 ```
 
-Python packages needed for building:
+During the build the `setup.py` script downloads the upstream PyMQI release and
+the IBM MQ Client runtime, bundling them into the resulting wheel. The setup
+script also falls back to system locations such as `/usr/lib/python3/dist-packages`
+to locate `setuptools` and `wheel` when they are not installed in the active
+environment, so only the two commands above are needed on a networked machine.
+
+## Build prerequisites
+
+Install required system tools and Python build helpers (example for yum-based
+distributions):
 
 ```bash
-python -m pip install build
-# Python 3.6 additionally requires the dataclasses backport
-python -m pip install dataclasses
+yum install -y gcc make curl tar rsync python3-setuptools python3-wheel
 ```
 
 ## Development

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,18 @@ import sys
 from pathlib import Path
 from typing import List
 
-from setuptools import Extension, find_packages, setup
+try:
+    from setuptools import Extension, find_packages, setup
+    import wheel.bdist_wheel  # noqa: F401 - ensure command is registered
+except ModuleNotFoundError:  # pragma: no cover - executed only in lean envs
+    for path in (
+        "/usr/lib/python3/dist-packages",
+        "/usr/local/lib/python3/dist-packages",
+    ):
+        if path not in sys.path:
+            sys.path.append(path)
+    from setuptools import Extension, find_packages, setup  # type: ignore
+    import wheel.bdist_wheel  # type: ignore # noqa: F401
 
 ROOT = Path(__file__).resolve().parent
 SRC = ROOT / "src"


### PR DESCRIPTION
## Summary
- search system `dist-packages` for `setuptools`/`wheel`
- document system fallback for build prerequisites

## Testing
- `python -m compileall`
- `python setup.py sdist bdist_wheel` *(fails: ProxyError 403 when downloading `pymqi`)*


------
https://chatgpt.com/codex/tasks/task_e_68b7425b867483259b3db4879c24f480